### PR TITLE
BAP-8368: Refactoring CAST function

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Available functions:
 * `YEAR(expr)` - Return the year from the date passed
 * `POW(expr, power)` - Return the argument raised to the specified power
 * `SIGN(expr)` - Return the sign of the argument
-* `CAST(expr as type)` - Takes an expression of any type and produces a result value of a specified type. Supported types are: "char, date, datetime, time, int, integer, decimal"
+* `CAST(expr as type)` - Takes an expression of any type and produces a result value of a specified type. Supported types are: "string, text, date, datetime, time, integer, decimal"
 * `GROUP_CONCAT` - Return a concatenated string
 
 GROUP_CONCAT full syntax:

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Available functions:
 * `YEAR(expr)` - Return the year from the date passed
 * `POW(expr, power)` - Return the argument raised to the specified power
 * `SIGN(expr)` - Return the sign of the argument
-* `CAST(expr as type)` - Takes an expression of any type and produces a result value of a specified type. Supported types are: "string, text, date, datetime, time, integer, decimal"
+* `CAST(expr as type)` - Takes an expression of any type and produces a result value of a specified type. Supported types are: "char, string, text, date, datetime, time, int, integer, decimal"
 * `GROUP_CONCAT` - Return a concatenated string
 
 GROUP_CONCAT full syntax:

--- a/src/Oro/ORM/Query/AST/Functions/Cast.php
+++ b/src/Oro/ORM/Query/AST/Functions/Cast.php
@@ -2,6 +2,8 @@
 
 namespace Oro\ORM\Query\AST\Functions;
 
+use Doctrine\DBAL\Types\Type;
+
 use Doctrine\ORM\Query\AST\Literal;
 use Doctrine\ORM\Query\Parser;
 use Doctrine\ORM\Query\Lexer;
@@ -10,16 +12,6 @@ class Cast extends AbstractPlatformAwareFunctionNode
 {
     const PARAMETER_KEY = 'expression';
     const TYPE_KEY = 'type';
-
-    protected $supportedTypes = array(
-        'char',
-        'date',
-        'datetime',
-        'time',
-        'int',
-        'integer',
-        'decimal'
-    );
 
     /**
      * {@inheritdoc}
@@ -58,7 +50,7 @@ class Cast extends AbstractPlatformAwareFunctionNode
             $parser->syntaxError(
                 sprintf(
                     'Type unsupported. Supported types are: "%s"',
-                    implode(', ', $this->supportedTypes)
+                    implode(', ', $this->getSupportedTypes())
                 ),
                 $lexer->token
             );
@@ -78,12 +70,16 @@ class Cast extends AbstractPlatformAwareFunctionNode
     protected function checkType($type)
     {
         $type = strtolower(trim($type));
-        foreach ($this->supportedTypes as $supportedType) {
-            if (strpos($type, $supportedType) === 0) {
-                return true;
-            }
-        }
+        return Type::hasType($type);
+    }
 
-        return false;
+    /**
+     * Gets supported types
+     *
+     * @return array
+     */
+    protected function getSupportedTypes()
+    {
+        return array_keys(Type::getTypesMap());
     }
 }

--- a/src/Oro/ORM/Query/AST/Functions/Cast.php
+++ b/src/Oro/ORM/Query/AST/Functions/Cast.php
@@ -2,8 +2,6 @@
 
 namespace Oro\ORM\Query\AST\Functions;
 
-use Doctrine\DBAL\Types\Type;
-
 use Doctrine\ORM\Query\AST\Literal;
 use Doctrine\ORM\Query\Parser;
 use Doctrine\ORM\Query\Lexer;
@@ -12,6 +10,18 @@ class Cast extends AbstractPlatformAwareFunctionNode
 {
     const PARAMETER_KEY = 'expression';
     const TYPE_KEY = 'type';
+
+    protected $supportedTypes = array(
+        'char',
+        'string',
+        'text',
+        'date',
+        'datetime',
+        'time',
+        'int',
+        'integer',
+        'decimal'
+    );
 
     /**
      * {@inheritdoc}
@@ -50,7 +60,7 @@ class Cast extends AbstractPlatformAwareFunctionNode
             $parser->syntaxError(
                 sprintf(
                     'Type unsupported. Supported types are: "%s"',
-                    implode(', ', $this->getSupportedTypes())
+                    implode(', ', $this->supportedTypes)
                 ),
                 $lexer->token
             );
@@ -70,16 +80,12 @@ class Cast extends AbstractPlatformAwareFunctionNode
     protected function checkType($type)
     {
         $type = strtolower(trim($type));
-        return Type::hasType($type);
-    }
+        foreach ($this->supportedTypes as $supportedType) {
+            if (strpos($type, $supportedType) === 0) {
+                return true;
+            }
+        }
 
-    /**
-     * Gets supported types
-     *
-     * @return array
-     */
-    protected function getSupportedTypes()
-    {
-        return array_keys(Type::getTypesMap());
+        return false;
     }
 }

--- a/src/Oro/ORM/Query/AST/Platform/Functions/Mysql/Cast.php
+++ b/src/Oro/ORM/Query/AST/Platform/Functions/Mysql/Cast.php
@@ -19,10 +19,12 @@ class Cast extends PlatformFunctionNode
         $type  = $this->parameters[DqlFunction::TYPE_KEY];
 
         $type = strtolower($type);
-        if ($type == 'integer') {
-            $type = 'signed';
-        } elseif (in_array($type, array('string', 'text'))) {
+        if ($type == 'char') {
+            $type = 'char(1)';
+        } elseif ($type == 'string' || $type == 'text') {
             $type = 'char';
+        } elseif ($type == 'int' || $type == 'integer') {
+            $type = 'signed';
         }
 
         return 'CAST(' . $this->getExpressionValue($value, $sqlWalker) . ' AS ' . $type . ')';

--- a/src/Oro/ORM/Query/AST/Platform/Functions/Mysql/Cast.php
+++ b/src/Oro/ORM/Query/AST/Platform/Functions/Mysql/Cast.php
@@ -16,13 +16,13 @@ class Cast extends PlatformFunctionNode
     {
         /** @var Node $value */
         $value = $this->parameters[DqlFunction::PARAMETER_KEY];
-        $type = $this->parameters[DqlFunction::TYPE_KEY];
+        $type  = $this->parameters[DqlFunction::TYPE_KEY];
 
         $type = strtolower($type);
-        if ($type == 'char') {
-            $type = 'char(1)';
-        } elseif ($type == 'int' || $type == 'integer') {
-            $type = 'unsigned';
+        if ($type == 'integer') {
+            $type = 'signed';
+        } elseif (in_array($type, array('string', 'text'))) {
+            $type = 'char';
         }
 
         return 'CAST(' . $this->getExpressionValue($value, $sqlWalker) . ' AS ' . $type . ')';

--- a/src/Oro/ORM/Query/AST/Platform/Functions/Postgresql/Cast.php
+++ b/src/Oro/ORM/Query/AST/Platform/Functions/Postgresql/Cast.php
@@ -27,6 +27,16 @@ class Cast extends PlatformFunctionNode
             return $timestampFunction->getSql($sqlWalker);
         }
 
+        /**
+         * The notations varchar(n) and char(n) are aliases for character varying(n) and character(n), respectively.
+         * character without length specifier is equivalent to character(1). If character varying is used
+         * without length specifier, the type accepts strings of any size. The latter is a PostgreSQL extension.
+         * http://www.postgresql.org/docs/9.2/static/datatype-character.html
+         */
+        if (strtolower($type) == 'string') {
+            $type = 'varchar';
+        }
+
         return 'CAST(' . $this->getExpressionValue($value, $sqlWalker) . ' AS ' . $type . ')';
     }
 }

--- a/tests/Oro/Tests/ORM/AST/Query/Functions/fixtures/mysql/cast.yml
+++ b/tests/Oro/Tests/ORM/AST/Query/Functions/fixtures/mysql/cast.yml
@@ -1,4 +1,12 @@
-#Type::INTEGER
+#INT
+- functions:
+    - { name: "cast", className: "Oro\\ORM\\Query\\AST\\Functions\\Cast", type: "numeric" }
+  dql: "SELECT CAST('123' as int) FROM Oro\\Entities\\Foo f WHERE f.id = 1"
+  sql: "SELECT CAST('123' AS signed) AS sclr0 FROM test_foo t0_ WHERE t0_.id = 1"
+  expectedResult:
+      - 123
+
+#INTEGER
 - functions:
     - { name: "cast", className: "Oro\\ORM\\Query\\AST\\Functions\\Cast", type: "numeric" }
   dql: "SELECT CAST('123' as integer) FROM Oro\\Entities\\Foo f WHERE f.id = 1"
@@ -6,7 +14,15 @@
   expectedResult:
       - 123
 
-#Type::STRING
+#CHAR
+- functions:
+    - { name: "cast", className: "Oro\\ORM\\Query\\AST\\Functions\\Cast", type: "numeric" }
+  dql: "SELECT CAST('12' as char) FROM Oro\\Entities\\Foo f WHERE f.id = 1"
+  sql: "SELECT CAST('12' AS char(1)) AS sclr0 FROM test_foo t0_ WHERE t0_.id = 1"
+  expectedResult:
+      - 1
+
+#STRING
 - functions:
     - { name: "cast", className: "Oro\\ORM\\Query\\AST\\Functions\\Cast", type: "numeric" }
   dql: "SELECT CAST(12 as string) FROM Oro\\Entities\\Foo f WHERE f.id = 1"
@@ -21,7 +37,7 @@
   expectedResult:
       - '2014-01-04 05:06:07'
 
-#Type::TEXT
+#TEXT
 - functions:
     - { name: "cast", className: "Oro\\ORM\\Query\\AST\\Functions\\Cast", type: "numeric" }
   dql: "SELECT CAST(12 as text) FROM Oro\\Entities\\Foo f WHERE f.id = 1"
@@ -36,7 +52,7 @@
   expectedResult:
       - '2014-01-04 05:06:07'
 
-#Type::DECIMAL
+#DECIMAL
 - functions:
     - { name: "cast", className: "Oro\\ORM\\Query\\AST\\Functions\\Cast", type: "numeric" }
   dql: "SELECT CAST('123' as decimal) FROM Oro\\Entities\\Foo f WHERE f.id = 1"
@@ -44,7 +60,7 @@
   expectedResult:
       - 123
 
-#Type::DATE
+#DATE
 - functions:
     - { name: "cast", className: "Oro\\ORM\\Query\\AST\\Functions\\Cast", type: "numeric" }
   dql: "SELECT CAST('2014-01-02 12:13:14' as date) FROM Oro\\Entities\\Foo f WHERE f.id = 1"
@@ -52,7 +68,7 @@
   expectedResult:
       - '2014-01-02'
 
-#Type::TIME
+#TIME
 - functions:
     - { name: "cast", className: "Oro\\ORM\\Query\\AST\\Functions\\Cast", type: "numeric" }
   dql: "SELECT CAST('2014-01-02 12:13:14' as time) FROM Oro\\Entities\\Foo f WHERE f.id = 1"
@@ -60,7 +76,7 @@
   expectedResult:
       - '12:13:14'
 
-#Type::DATETIME
+#DATETIME
 - functions:
     - { name: "cast", className: "Oro\\ORM\\Query\\AST\\Functions\\Cast", type: "numeric" }
   dql: "SELECT CAST('2014-01-02 12:13:14' as datetime) FROM Oro\\Entities\\Foo f WHERE f.id = 1"

--- a/tests/Oro/Tests/ORM/AST/Query/Functions/fixtures/mysql/cast.yml
+++ b/tests/Oro/Tests/ORM/AST/Query/Functions/fixtures/mysql/cast.yml
@@ -22,6 +22,13 @@
   expectedResult:
       - 1
 
+- functions:
+    - { name: "cast", className: "Oro\\ORM\\Query\\AST\\Functions\\Cast", type: "numeric" }
+  dql: "SELECT CAST(f.createdAt as char) FROM Oro\\Entities\\Foo f WHERE f.id = 1"
+  sql: "SELECT CAST(t0_.created_at AS char(1)) AS sclr0 FROM test_foo t0_ WHERE t0_.id = 1"
+  expectedResult:
+      - '2'
+
 #STRING
 - functions:
     - { name: "cast", className: "Oro\\ORM\\Query\\AST\\Functions\\Cast", type: "numeric" }

--- a/tests/Oro/Tests/ORM/AST/Query/Functions/fixtures/mysql/cast.yml
+++ b/tests/Oro/Tests/ORM/AST/Query/Functions/fixtures/mysql/cast.yml
@@ -1,31 +1,42 @@
-- functions:
-    - { name: "cast", className: "Oro\\ORM\\Query\\AST\\Functions\\Cast", type: "numeric" }
-  dql: "SELECT CAST(12 as int) FROM Oro\\Entities\\Foo f WHERE f.id = 1"
-  sql: "SELECT CAST(12 AS unsigned) AS sclr0 FROM test_foo t0_ WHERE t0_.id = 1"
-  expectedResult:
-      - 12
-
-- functions:
-    - { name: "cast", className: "Oro\\ORM\\Query\\AST\\Functions\\Cast", type: "numeric" }
-  dql: "SELECT CAST('12' as int) FROM Oro\\Entities\\Foo f WHERE f.id = 1"
-  sql: "SELECT CAST('12' AS unsigned) AS sclr0 FROM test_foo t0_ WHERE t0_.id = 1"
-  expectedResult:
-      - 12
-
+#Type::INTEGER
 - functions:
     - { name: "cast", className: "Oro\\ORM\\Query\\AST\\Functions\\Cast", type: "numeric" }
   dql: "SELECT CAST('123' as integer) FROM Oro\\Entities\\Foo f WHERE f.id = 1"
-  sql: "SELECT CAST('123' AS unsigned) AS sclr0 FROM test_foo t0_ WHERE t0_.id = 1"
+  sql: "SELECT CAST('123' AS signed) AS sclr0 FROM test_foo t0_ WHERE t0_.id = 1"
   expectedResult:
       - 123
 
+#Type::STRING
 - functions:
     - { name: "cast", className: "Oro\\ORM\\Query\\AST\\Functions\\Cast", type: "numeric" }
-  dql: "SELECT CAST('12' as char) FROM Oro\\Entities\\Foo f WHERE f.id = 1"
-  sql: "SELECT CAST('12' AS char(1)) AS sclr0 FROM test_foo t0_ WHERE t0_.id = 1"
+  dql: "SELECT CAST(12 as string) FROM Oro\\Entities\\Foo f WHERE f.id = 1"
+  sql: "SELECT CAST(12 AS char) AS sclr0 FROM test_foo t0_ WHERE t0_.id = 1"
   expectedResult:
-      - 1
+      - '12'
 
+- functions:
+    - { name: "cast", className: "Oro\\ORM\\Query\\AST\\Functions\\Cast", type: "numeric" }
+  dql: "SELECT CAST(f.createdAt as string) FROM Oro\\Entities\\Foo f WHERE f.id = 1"
+  sql: "SELECT CAST(t0_.created_at AS char) AS sclr0 FROM test_foo t0_ WHERE t0_.id = 1"
+  expectedResult:
+      - '2014-01-04 05:06:07'
+
+#Type::TEXT
+- functions:
+    - { name: "cast", className: "Oro\\ORM\\Query\\AST\\Functions\\Cast", type: "numeric" }
+  dql: "SELECT CAST(12 as text) FROM Oro\\Entities\\Foo f WHERE f.id = 1"
+  sql: "SELECT CAST(12 AS char) AS sclr0 FROM test_foo t0_ WHERE t0_.id = 1"
+  expectedResult:
+      - '12'
+
+- functions:
+    - { name: "cast", className: "Oro\\ORM\\Query\\AST\\Functions\\Cast", type: "numeric" }
+  dql: "SELECT CAST(f.createdAt as text) FROM Oro\\Entities\\Foo f WHERE f.id = 1"
+  sql: "SELECT CAST(t0_.created_at AS char) AS sclr0 FROM test_foo t0_ WHERE t0_.id = 1"
+  expectedResult:
+      - '2014-01-04 05:06:07'
+
+#Type::DECIMAL
 - functions:
     - { name: "cast", className: "Oro\\ORM\\Query\\AST\\Functions\\Cast", type: "numeric" }
   dql: "SELECT CAST('123' as decimal) FROM Oro\\Entities\\Foo f WHERE f.id = 1"
@@ -33,6 +44,7 @@
   expectedResult:
       - 123
 
+#Type::DATE
 - functions:
     - { name: "cast", className: "Oro\\ORM\\Query\\AST\\Functions\\Cast", type: "numeric" }
   dql: "SELECT CAST('2014-01-02 12:13:14' as date) FROM Oro\\Entities\\Foo f WHERE f.id = 1"
@@ -40,6 +52,7 @@
   expectedResult:
       - '2014-01-02'
 
+#Type::TIME
 - functions:
     - { name: "cast", className: "Oro\\ORM\\Query\\AST\\Functions\\Cast", type: "numeric" }
   dql: "SELECT CAST('2014-01-02 12:13:14' as time) FROM Oro\\Entities\\Foo f WHERE f.id = 1"
@@ -47,6 +60,7 @@
   expectedResult:
       - '12:13:14'
 
+#Type::DATETIME
 - functions:
     - { name: "cast", className: "Oro\\ORM\\Query\\AST\\Functions\\Cast", type: "numeric" }
   dql: "SELECT CAST('2014-01-02 12:13:14' as datetime) FROM Oro\\Entities\\Foo f WHERE f.id = 1"
@@ -60,10 +74,3 @@
   sql: "SELECT CAST(t0_.created_at AS datetime) AS sclr0 FROM test_foo t0_ WHERE t0_.id = 1"
   expectedResult:
       - '2014-01-04 05:06:07'
-
-- functions:
-    - { name: "cast", className: "Oro\\ORM\\Query\\AST\\Functions\\Cast", type: "numeric" }
-  dql: "SELECT CAST(f.createdAt as char) FROM Oro\\Entities\\Foo f WHERE f.id = 1"
-  sql: "SELECT CAST(t0_.created_at AS char(1)) AS sclr0 FROM test_foo t0_ WHERE t0_.id = 1"
-  expectedResult:
-      - '2'

--- a/tests/Oro/Tests/ORM/AST/Query/Functions/fixtures/postgresql/cast.yml
+++ b/tests/Oro/Tests/ORM/AST/Query/Functions/fixtures/postgresql/cast.yml
@@ -29,6 +29,13 @@
   expectedResult:
       - 1
 
+- functions:
+    - { name: "cast", className: "Oro\\ORM\\Query\\AST\\Functions\\Cast", type: "numeric" }
+  dql: "SELECT CAST(f.createdAt as char) FROM Oro\\Entities\\Foo f WHERE f.id = 1"
+  sql: "SELECT CAST(t0_.created_at AS char) AS sclr0 FROM test_foo t0_ WHERE t0_.id = 1"
+  expectedResult:
+      - '2'
+
 #STRING
 - functions:
     - { name: "cast", className: "Oro\\ORM\\Query\\AST\\Functions\\Cast", type: "numeric" }

--- a/tests/Oro/Tests/ORM/AST/Query/Functions/fixtures/postgresql/cast.yml
+++ b/tests/Oro/Tests/ORM/AST/Query/Functions/fixtures/postgresql/cast.yml
@@ -1,4 +1,19 @@
-#Type::INTEGER
+#INT
+- functions:
+    - { name: "cast", className: "Oro\\ORM\\Query\\AST\\Functions\\Cast", type: "numeric" }
+  dql: "SELECT CAST(12 as int) FROM Oro\\Entities\\Foo f WHERE f.id = 1"
+  sql: "SELECT CAST(12 AS int) AS sclr0 FROM test_foo t0_ WHERE t0_.id = 1"
+  expectedResult:
+      - 12
+
+- functions:
+    - { name: "cast", className: "Oro\\ORM\\Query\\AST\\Functions\\Cast", type: "numeric" }
+  dql: "SELECT CAST('12' as int) FROM Oro\\Entities\\Foo f WHERE f.id = 1"
+  sql: "SELECT CAST('12' AS int) AS sclr0 FROM test_foo t0_ WHERE t0_.id = 1"
+  expectedResult:
+      - 12
+
+#INTEGER
 - functions:
     - { name: "cast", className: "Oro\\ORM\\Query\\AST\\Functions\\Cast", type: "numeric" }
   dql: "SELECT CAST('123' as integer) FROM Oro\\Entities\\Foo f WHERE f.id = 1"
@@ -6,7 +21,15 @@
   expectedResult:
       - 123
 
-#Type::STRING
+#CHAR
+- functions:
+    - { name: "cast", className: "Oro\\ORM\\Query\\AST\\Functions\\Cast", type: "numeric" }
+  dql: "SELECT CAST('12' as char) FROM Oro\\Entities\\Foo f WHERE f.id = 1"
+  sql: "SELECT CAST('12' AS char) AS sclr0 FROM test_foo t0_ WHERE t0_.id = 1"
+  expectedResult:
+      - 1
+
+#STRING
 - functions:
     - { name: "cast", className: "Oro\\ORM\\Query\\AST\\Functions\\Cast", type: "numeric" }
   dql: "SELECT CAST(12 as string) FROM Oro\\Entities\\Foo f WHERE f.id = 1"
@@ -21,7 +44,7 @@
   expectedResult:
       - '2014-01-04 05:06:07'
 
-#Type::TEXT
+#TEXT
 - functions:
     - { name: "cast", className: "Oro\\ORM\\Query\\AST\\Functions\\Cast", type: "numeric" }
   dql: "SELECT CAST(12 as text) FROM Oro\\Entities\\Foo f WHERE f.id = 1"
@@ -36,7 +59,7 @@
   expectedResult:
       - '2014-01-04 05:06:07'
 
-#Type::DECIMAL
+#DECIMAL
 - functions:
     - { name: "cast", className: "Oro\\ORM\\Query\\AST\\Functions\\Cast", type: "numeric" }
   dql: "SELECT CAST('123' as decimal) FROM Oro\\Entities\\Foo f WHERE f.id = 1"
@@ -44,7 +67,7 @@
   expectedResult:
       - 123
 
-#Type::DATE
+#DATE
 - functions:
     - { name: "cast", className: "Oro\\ORM\\Query\\AST\\Functions\\Cast", type: "numeric" }
   dql: "SELECT CAST('2014-01-02 12:13:14' as date) FROM Oro\\Entities\\Foo f WHERE f.id = 1"
@@ -52,7 +75,7 @@
   expectedResult:
       - '2014-01-02'
 
-#Type::TIME
+#TIME
 - functions:
     - { name: "cast", className: "Oro\\ORM\\Query\\AST\\Functions\\Cast", type: "numeric" }
   dql: "SELECT CAST('2014-01-02 12:13:14' as time) FROM Oro\\Entities\\Foo f WHERE f.id = 1"
@@ -60,7 +83,7 @@
   expectedResult:
       - '12:13:14'
 
-#Type::DATETIME
+#DATETIME
 - functions:
     - { name: "cast", className: "Oro\\ORM\\Query\\AST\\Functions\\Cast", type: "numeric" }
   dql: "SELECT CAST('2014-01-02 12:13:14' as datetime) FROM Oro\\Entities\\Foo f WHERE f.id = 1"

--- a/tests/Oro/Tests/ORM/AST/Query/Functions/fixtures/postgresql/cast.yml
+++ b/tests/Oro/Tests/ORM/AST/Query/Functions/fixtures/postgresql/cast.yml
@@ -1,32 +1,42 @@
-- functions:
-    - { name: "cast", className: "Oro\\ORM\\Query\\AST\\Functions\\Cast", type: "numeric" }
-  dql: "SELECT CAST(12 as int) FROM Oro\\Entities\\Foo f WHERE f.id = 1"
-  sql: "SELECT CAST(12 AS int) AS sclr0 FROM test_foo t0_ WHERE t0_.id = 1"
-  expectedResult:
-      - 12
-
-- functions:
-    - { name: "cast", className: "Oro\\ORM\\Query\\AST\\Functions\\Cast", type: "numeric" }
-  dql: "SELECT CAST('12' as int) FROM Oro\\Entities\\Foo f WHERE f.id = 1"
-  sql: "SELECT CAST('12' AS int) AS sclr0 FROM test_foo t0_ WHERE t0_.id = 1"
-  expectedResult:
-      - 12
-
+#Type::INTEGER
 - functions:
     - { name: "cast", className: "Oro\\ORM\\Query\\AST\\Functions\\Cast", type: "numeric" }
   dql: "SELECT CAST('123' as integer) FROM Oro\\Entities\\Foo f WHERE f.id = 1"
   sql: "SELECT CAST('123' AS integer) AS sclr0 FROM test_foo t0_ WHERE t0_.id = 1"
-  sql: "SELECT CAST('123' AS integer) AS sclr0 FROM test_foo t0_ WHERE t0_.id = 1"
   expectedResult:
       - 123
 
+#Type::STRING
 - functions:
     - { name: "cast", className: "Oro\\ORM\\Query\\AST\\Functions\\Cast", type: "numeric" }
-  dql: "SELECT CAST('12' as char) FROM Oro\\Entities\\Foo f WHERE f.id = 1"
-  sql: "SELECT CAST('12' AS char) AS sclr0 FROM test_foo t0_ WHERE t0_.id = 1"
+  dql: "SELECT CAST(12 as string) FROM Oro\\Entities\\Foo f WHERE f.id = 1"
+  sql: "SELECT CAST(12 AS varchar) AS sclr0 FROM test_foo t0_ WHERE t0_.id = 1"
   expectedResult:
-      - 1
+      - '12'
 
+- functions:
+    - { name: "cast", className: "Oro\\ORM\\Query\\AST\\Functions\\Cast", type: "numeric" }
+  dql: "SELECT CAST(f.createdAt as string) FROM Oro\\Entities\\Foo f WHERE f.id = 1"
+  sql: "SELECT CAST(t0_.created_at AS varchar) AS sclr0 FROM test_foo t0_ WHERE t0_.id = 1"
+  expectedResult:
+      - '2014-01-04 05:06:07'
+
+#Type::TEXT
+- functions:
+    - { name: "cast", className: "Oro\\ORM\\Query\\AST\\Functions\\Cast", type: "numeric" }
+  dql: "SELECT CAST(12 as text) FROM Oro\\Entities\\Foo f WHERE f.id = 1"
+  sql: "SELECT CAST(12 AS text) AS sclr0 FROM test_foo t0_ WHERE t0_.id = 1"
+  expectedResult:
+      - '12'
+
+- functions:
+    - { name: "cast", className: "Oro\\ORM\\Query\\AST\\Functions\\Cast", type: "numeric" }
+  dql: "SELECT CAST(f.createdAt as text) FROM Oro\\Entities\\Foo f WHERE f.id = 1"
+  sql: "SELECT CAST(t0_.created_at AS text) AS sclr0 FROM test_foo t0_ WHERE t0_.id = 1"
+  expectedResult:
+      - '2014-01-04 05:06:07'
+
+#Type::DECIMAL
 - functions:
     - { name: "cast", className: "Oro\\ORM\\Query\\AST\\Functions\\Cast", type: "numeric" }
   dql: "SELECT CAST('123' as decimal) FROM Oro\\Entities\\Foo f WHERE f.id = 1"
@@ -34,6 +44,7 @@
   expectedResult:
       - 123
 
+#Type::DATE
 - functions:
     - { name: "cast", className: "Oro\\ORM\\Query\\AST\\Functions\\Cast", type: "numeric" }
   dql: "SELECT CAST('2014-01-02 12:13:14' as date) FROM Oro\\Entities\\Foo f WHERE f.id = 1"
@@ -41,6 +52,7 @@
   expectedResult:
       - '2014-01-02'
 
+#Type::TIME
 - functions:
     - { name: "cast", className: "Oro\\ORM\\Query\\AST\\Functions\\Cast", type: "numeric" }
   dql: "SELECT CAST('2014-01-02 12:13:14' as time) FROM Oro\\Entities\\Foo f WHERE f.id = 1"
@@ -48,6 +60,7 @@
   expectedResult:
       - '12:13:14'
 
+#Type::DATETIME
 - functions:
     - { name: "cast", className: "Oro\\ORM\\Query\\AST\\Functions\\Cast", type: "numeric" }
   dql: "SELECT CAST('2014-01-02 12:13:14' as datetime) FROM Oro\\Entities\\Foo f WHERE f.id = 1"
@@ -61,10 +74,3 @@
   sql: SELECT "timestamp"(t0_.created_at) AS sclr0 FROM test_foo t0_ WHERE t0_.id = 1
   expectedResult:
       - '2014-01-04 05:06:07'
-
-- functions:
-    - { name: "cast", className: "Oro\\ORM\\Query\\AST\\Functions\\Cast", type: "numeric" }
-  dql: "SELECT CAST(f.createdAt as char) FROM Oro\\Entities\\Foo f WHERE f.id = 1"
-  sql: "SELECT CAST(t0_.created_at AS char) AS sclr0 FROM test_foo t0_ WHERE t0_.id = 1"
-  expectedResult:
-      - '2'


### PR DESCRIPTION
 - Removed  support for the "int" and "char" types.
 - Added support for "string" and "text" types.
 - Added possibility for using supported types from Doctrine\DBAL\Types\Type.