### PR TITLE
BAP-9655: Doctrine extensions: TIMESTAMPDIFF function does not work properly in PostgeSQL

### DIFF
--- a/tests/Oro/Tests/ORM/AST/Query/Functions/fixtures/mysql/cast.yml
+++ b/tests/Oro/Tests/ORM/AST/Query/Functions/fixtures/mysql/cast.yml
@@ -1,10 +1,17 @@
 #INT
 - functions:
     - { name: "cast", className: "Oro\\ORM\\Query\\AST\\Functions\\Cast", type: "numeric" }
-  dql: "SELECT CAST('123' as int) FROM Oro\\Entities\\Foo f WHERE f.id = 1"
-  sql: "SELECT CAST('123' AS signed) AS sclr0 FROM test_foo t0_ WHERE t0_.id = 1"
+  dql: "SELECT CAST(12 as int) FROM Oro\\Entities\\Foo f WHERE f.id = 1"
+  sql: "SELECT CAST(12 AS signed) AS sclr0 FROM test_foo t0_ WHERE t0_.id = 1"
   expectedResult:
-      - 123
+      - 12
+
+- functions:
+    - { name: "cast", className: "Oro\\ORM\\Query\\AST\\Functions\\Cast", type: "numeric" }
+  dql: "SELECT CAST('12' as int) FROM Oro\\Entities\\Foo f WHERE f.id = 1"
+  sql: "SELECT CAST('12' AS signed) AS sclr0 FROM test_foo t0_ WHERE t0_.id = 1"
+  expectedResult:
+      - 12
 
 #INTEGER
 - functions:

--- a/tests/Oro/Tests/ORM/AST/Query/Functions/fixtures/mysql/timestampdiff.yml
+++ b/tests/Oro/Tests/ORM/AST/Query/Functions/fixtures/mysql/timestampdiff.yml
@@ -35,6 +35,20 @@
 
 - functions:
     - { name: "timestampdiff", className: "Oro\\ORM\\Query\\AST\\Functions\\Numeric\\TimestampDiff", type: "numeric" }
+  dql: "SELECT TIMESTAMPDIFF(DAY, '2016-01-01 00:00:00', '2017-01-01 00:00:00') FROM Oro\\Entities\\Foo f WHERE f.id = 1"
+  sql: SELECT TIMESTAMPDIFF(DAY, '2016-01-01 00:00:00', '2017-01-01 00:00:00') AS sclr0 FROM test_foo t0_ WHERE t0_.id = 1
+  expectedResult:
+      - 366
+
+- functions:
+    - { name: "timestampdiff", className: "Oro\\ORM\\Query\\AST\\Functions\\Numeric\\TimestampDiff", type: "numeric" }
+  dql: "SELECT TIMESTAMPDIFF(DAY, '2016-01-01 00:00:00', '2017-01-02 00:10:00') FROM Oro\\Entities\\Foo f WHERE f.id = 1"
+  sql: SELECT TIMESTAMPDIFF(DAY, '2016-01-01 00:00:00', '2017-01-02 00:10:00') AS sclr0 FROM test_foo t0_ WHERE t0_.id = 1
+  expectedResult:
+      - 367
+
+- functions:
+    - { name: "timestampdiff", className: "Oro\\ORM\\Query\\AST\\Functions\\Numeric\\TimestampDiff", type: "numeric" }
   dql: "SELECT TIMESTAMPDIFF(WEEK, '2014-01-01 00:00:00', '2014-03-15 10:10:10') FROM Oro\\Entities\\Foo f WHERE f.id = 1"
   sql: SELECT TIMESTAMPDIFF(WEEK, '2014-01-01 00:00:00', '2014-03-15 10:10:10') AS sclr0 FROM test_foo t0_ WHERE t0_.id = 1
   expectedResult:
@@ -42,10 +56,24 @@
 
 - functions:
     - { name: "timestampdiff", className: "Oro\\ORM\\Query\\AST\\Functions\\Numeric\\TimestampDiff", type: "numeric" }
-  dql: "SELECT TIMESTAMPDIFF(MONTH, '2014-01-01 00:00:00', '2014-03-15 10:10:10') FROM Oro\\Entities\\Foo f WHERE f.id = 1"
-  sql: SELECT TIMESTAMPDIFF(MONTH, '2014-01-01 00:00:00', '2014-03-15 10:10:10') AS sclr0 FROM test_foo t0_ WHERE t0_.id = 1
+  dql: "SELECT TIMESTAMPDIFF(MONTH, '2016-01-01 00:00:00', '2017-01-01 00:00:00') FROM Oro\\Entities\\Foo f WHERE f.id = 1"
+  sql: SELECT TIMESTAMPDIFF(MONTH, '2016-01-01 00:00:00', '2017-01-01 00:00:00') AS sclr0 FROM test_foo t0_ WHERE t0_.id = 1
   expectedResult:
-      - 2
+      - 12
+
+- functions:
+    - { name: "timestampdiff", className: "Oro\\ORM\\Query\\AST\\Functions\\Numeric\\TimestampDiff", type: "numeric" }
+  dql: "SELECT TIMESTAMPDIFF(MONTH, '2016-01-01 00:00:01', '2017-01-01 00:00:00') FROM Oro\\Entities\\Foo f WHERE f.id = 1"
+  sql: SELECT TIMESTAMPDIFF(MONTH, '2016-01-01 00:00:01', '2017-01-01 00:00:00') AS sclr0 FROM test_foo t0_ WHERE t0_.id = 1
+  expectedResult:
+      - 11
+
+- functions:
+    - { name: "timestampdiff", className: "Oro\\ORM\\Query\\AST\\Functions\\Numeric\\TimestampDiff", type: "numeric" }
+  dql: "SELECT TIMESTAMPDIFF(MONTH, '2016-01-01 00:00:01', '2017-02-01 00:00:02') FROM Oro\\Entities\\Foo f WHERE f.id = 1"
+  sql: SELECT TIMESTAMPDIFF(MONTH, '2016-01-01 00:00:01', '2017-02-01 00:00:02') AS sclr0 FROM test_foo t0_ WHERE t0_.id = 1
+  expectedResult:
+      - 13
 
 - functions:
     - { name: "timestampdiff", className: "Oro\\ORM\\Query\\AST\\Functions\\Numeric\\TimestampDiff", type: "numeric" }
@@ -56,7 +84,22 @@
 
 - functions:
     - { name: "timestampdiff", className: "Oro\\ORM\\Query\\AST\\Functions\\Numeric\\TimestampDiff", type: "numeric" }
-  dql: "SELECT TIMESTAMPDIFF(YEAR, '2014-01-01 00:00:00', '2015-04-15 10:10:10') FROM Oro\\Entities\\Foo f WHERE f.id = 1"
-  sql: SELECT TIMESTAMPDIFF(YEAR, '2014-01-01 00:00:00', '2015-04-15 10:10:10') AS sclr0 FROM test_foo t0_ WHERE t0_.id = 1
+  dql: "SELECT TIMESTAMPDIFF(QUARTER, '2016-01-01 00:00:01', '2016-06-01 00:00:00') FROM Oro\\Entities\\Foo f WHERE f.id = 1"
+  sql: SELECT TIMESTAMPDIFF(QUARTER, '2016-01-01 00:00:01', '2016-06-01 00:00:00') AS sclr0 FROM test_foo t0_ WHERE t0_.id = 1
   expectedResult:
       - 1
+
+- functions:
+    - { name: "timestampdiff", className: "Oro\\ORM\\Query\\AST\\Functions\\Numeric\\TimestampDiff", type: "numeric" }
+  dql: "SELECT TIMESTAMPDIFF(YEAR, '2016-01-01 00:00:00', '2017-01-01 00:00:00') FROM Oro\\Entities\\Foo f WHERE f.id = 1"
+  sql: SELECT TIMESTAMPDIFF(YEAR, '2016-01-01 00:00:00', '2017-01-01 00:00:00') AS sclr0 FROM test_foo t0_ WHERE t0_.id = 1
+  expectedResult:
+      - 1
+
+- functions:
+    - { name: "timestampdiff", className: "Oro\\ORM\\Query\\AST\\Functions\\Numeric\\TimestampDiff", type: "numeric" }
+  dql: "SELECT TIMESTAMPDIFF(YEAR, '2016-01-01 00:00:01', '2017-01-01 00:00:00') FROM Oro\\Entities\\Foo f WHERE f.id = 1"
+  sql: SELECT TIMESTAMPDIFF(YEAR, '2016-01-01 00:00:01', '2017-01-01 00:00:00') AS sclr0 FROM test_foo t0_ WHERE t0_.id = 1
+  expectedResult:
+      - 0
+

--- a/tests/Oro/Tests/ORM/AST/Query/Functions/fixtures/mysql/timestampdiff.yml
+++ b/tests/Oro/Tests/ORM/AST/Query/Functions/fixtures/mysql/timestampdiff.yml
@@ -7,15 +7,29 @@
 
 - functions:
     - { name: "timestampdiff", className: "Oro\\ORM\\Query\\AST\\Functions\\Numeric\\TimestampDiff", type: "numeric" }
-  dql: "SELECT TIMESTAMPDIFF(SECOND, '2014-01-01 00:00:00', '2014-01-01 00:00:10') FROM Oro\\Entities\\Foo f WHERE f.id = 1"
-  sql: SELECT TIMESTAMPDIFF(SECOND, '2014-01-01 00:00:00', '2014-01-01 00:00:10') AS sclr0 FROM test_foo t0_ WHERE t0_.id = 1
+  dql: "SELECT TIMESTAMPDIFF(MICROSECOND, '2014-01-01 00:00:00.121212', '2014-01-01 00:00:03') FROM Oro\\Entities\\Foo f WHERE f.id = 1"
+  sql: SELECT TIMESTAMPDIFF(MICROSECOND, '2014-01-01 00:00:00.121212', '2014-01-01 00:00:03') AS sclr0 FROM test_foo t0_ WHERE t0_.id = 1
   expectedResult:
-      - 10
+      - 2878788
 
 - functions:
     - { name: "timestampdiff", className: "Oro\\ORM\\Query\\AST\\Functions\\Numeric\\TimestampDiff", type: "numeric" }
-  dql: "SELECT TIMESTAMPDIFF(MINUTE, '2014-01-01 00:00:00', '2014-01-01 00:10:10') FROM Oro\\Entities\\Foo f WHERE f.id = 1"
-  sql: SELECT TIMESTAMPDIFF(MINUTE, '2014-01-01 00:00:00', '2014-01-01 00:10:10') AS sclr0 FROM test_foo t0_ WHERE t0_.id = 1
+  dql: "SELECT TIMESTAMPDIFF(SECOND, '2014-01-01 00:00:00.123', '2014-01-01 00:00:10') FROM Oro\\Entities\\Foo f WHERE f.id = 1"
+  sql: SELECT TIMESTAMPDIFF(SECOND, '2014-01-01 00:00:00.123', '2014-01-01 00:00:10') AS sclr0 FROM test_foo t0_ WHERE t0_.id = 1
+  expectedResult:
+      - 9
+
+- functions:
+    - { name: "timestampdiff", className: "Oro\\ORM\\Query\\AST\\Functions\\Numeric\\TimestampDiff", type: "numeric" }
+  dql: "SELECT TIMESTAMPDIFF(SECOND, '2014-01-01 00:00:00.111', '2014-01-01 00:00:07.845') FROM Oro\\Entities\\Foo f WHERE f.id = 1"
+  sql: SELECT TIMESTAMPDIFF(SECOND, '2014-01-01 00:00:00.111', '2014-01-01 00:00:07.845') AS sclr0 FROM test_foo t0_ WHERE t0_.id = 1
+  expectedResult:
+      - 7
+
+- functions:
+    - { name: "timestampdiff", className: "Oro\\ORM\\Query\\AST\\Functions\\Numeric\\TimestampDiff", type: "numeric" }
+  dql: "SELECT TIMESTAMPDIFF(MINUTE, '2014-01-01 00:00:00', '2014-01-01 00:10:40') FROM Oro\\Entities\\Foo f WHERE f.id = 1"
+  sql: SELECT TIMESTAMPDIFF(MINUTE, '2014-01-01 00:00:00', '2014-01-01 00:10:40') AS sclr0 FROM test_foo t0_ WHERE t0_.id = 1
   expectedResult:
       - 10
 

--- a/tests/Oro/Tests/ORM/AST/Query/Functions/fixtures/postgresql/timestampdiff.yml
+++ b/tests/Oro/Tests/ORM/AST/Query/Functions/fixtures/postgresql/timestampdiff.yml
@@ -1,28 +1,42 @@
 - functions:
     - { name: "timestampdiff", className: "Oro\\ORM\\Query\\AST\\Functions\\Numeric\\TimestampDiff", type: "numeric" }
   dql: "SELECT TIMESTAMPDIFF(MICROSECOND, '2014-01-01 00:00:00', '2014-01-01 00:00:10.100') FROM Oro\\Entities\\Foo f WHERE f.id = 1"
-  sql: SELECT CAST(ROUND((EXTRACT(EPOCH FROM "timestamp"('2014-01-01 00:00:10.100')) - EXTRACT(EPOCH FROM "timestamp"('2014-01-01 00:00:00'))) * 1000000) AS int) AS sclr0 FROM test_foo t0_ WHERE t0_.id = 1
+  sql: SELECT EXTRACT(MICROSECOND FROM "timestamp"('2014-01-01 00:00:10.100') - "timestamp"('2014-01-01 00:00:00')) AS sclr0 FROM test_foo t0_ WHERE t0_.id = 1
   expectedResult:
       - 10100000
 
 - functions:
     - { name: "timestampdiff", className: "Oro\\ORM\\Query\\AST\\Functions\\Numeric\\TimestampDiff", type: "numeric" }
-  dql: "SELECT TIMESTAMPDIFF(SECOND, '2014-01-01 00:00:00', '2014-01-01 00:00:10') FROM Oro\\Entities\\Foo f WHERE f.id = 1"
-  sql: SELECT (EXTRACT(EPOCH FROM "timestamp"('2014-01-01 00:00:10')) - EXTRACT(EPOCH FROM "timestamp"('2014-01-01 00:00:00'))) AS sclr0 FROM test_foo t0_ WHERE t0_.id = 1
+  dql: "SELECT TIMESTAMPDIFF(MICROSECOND, '2014-01-01 00:00:00.121212', '2014-01-01 00:00:03') FROM Oro\\Entities\\Foo f WHERE f.id = 1"
+  sql: SELECT EXTRACT(MICROSECOND FROM "timestamp"('2014-01-01 00:00:03') - "timestamp"('2014-01-01 00:00:00.121212')) AS sclr0 FROM test_foo t0_ WHERE t0_.id = 1
   expectedResult:
-      - 10
+      - 2878788
 
 - functions:
     - { name: "timestampdiff", className: "Oro\\ORM\\Query\\AST\\Functions\\Numeric\\TimestampDiff", type: "numeric" }
-  dql: "SELECT TIMESTAMPDIFF(MINUTE, '2014-01-01 00:00:00', '2014-01-01 00:10:10') FROM Oro\\Entities\\Foo f WHERE f.id = 1"
-  sql: SELECT CAST(ROUND((EXTRACT(EPOCH FROM "timestamp"('2014-01-01 00:10:10')) - EXTRACT(EPOCH FROM "timestamp"('2014-01-01 00:00:00'))) / 60) AS int) AS sclr0 FROM test_foo t0_ WHERE t0_.id = 1
+  dql: "SELECT TIMESTAMPDIFF(SECOND, '2014-01-01 00:00:00.123', '2014-01-01 00:00:10') FROM Oro\\Entities\\Foo f WHERE f.id = 1"
+  sql: SELECT FLOOR(EXTRACT(EPOCH FROM "timestamp"('2014-01-01 00:00:10') - "timestamp"('2014-01-01 00:00:00.123'))) AS sclr0 FROM test_foo t0_ WHERE t0_.id = 1
+  expectedResult:
+      - 9
+
+- functions:
+    - { name: "timestampdiff", className: "Oro\\ORM\\Query\\AST\\Functions\\Numeric\\TimestampDiff", type: "numeric" }
+  dql: "SELECT TIMESTAMPDIFF(SECOND, '2014-01-01 00:00:00.111', '2014-01-01 00:00:07.845') FROM Oro\\Entities\\Foo f WHERE f.id = 1"
+  sql: SELECT FLOOR(EXTRACT(EPOCH FROM "timestamp"('2014-01-01 00:00:07.845') - "timestamp"('2014-01-01 00:00:00.111'))) AS sclr0 FROM test_foo t0_ WHERE t0_.id = 1
+  expectedResult:
+      - 7
+
+- functions:
+    - { name: "timestampdiff", className: "Oro\\ORM\\Query\\AST\\Functions\\Numeric\\TimestampDiff", type: "numeric" }
+  dql: "SELECT TIMESTAMPDIFF(MINUTE, '2014-01-01 00:00:00', '2014-01-01 00:10:40') FROM Oro\\Entities\\Foo f WHERE f.id = 1"
+  sql: SELECT FLOOR(EXTRACT(EPOCH FROM "timestamp"('2014-01-01 00:10:40') - "timestamp"('2014-01-01 00:00:00')) / 60) AS sclr0 FROM test_foo t0_ WHERE t0_.id = 1
   expectedResult:
       - 10
 
 - functions:
     - { name: "timestampdiff", className: "Oro\\ORM\\Query\\AST\\Functions\\Numeric\\TimestampDiff", type: "numeric" }
   dql: "SELECT TIMESTAMPDIFF(HOUR, '2014-01-01 00:00:00', '2014-01-01 10:10:10') FROM Oro\\Entities\\Foo f WHERE f.id = 1"
-  sql: SELECT CAST(ROUND((EXTRACT(EPOCH FROM "timestamp"('2014-01-01 10:10:10')) - EXTRACT(EPOCH FROM "timestamp"('2014-01-01 00:00:00'))) / 3600) AS int) AS sclr0 FROM test_foo t0_ WHERE t0_.id = 1
+  sql: SELECT FLOOR(EXTRACT(EPOCH FROM "timestamp"('2014-01-01 10:10:10') - "timestamp"('2014-01-01 00:00:00')) / 3600) AS sclr0 FROM test_foo t0_ WHERE t0_.id = 1
   expectedResult:
       - 10
 
@@ -50,7 +64,7 @@
 - functions:
     - { name: "timestampdiff", className: "Oro\\ORM\\Query\\AST\\Functions\\Numeric\\TimestampDiff", type: "numeric" }
   dql: "SELECT TIMESTAMPDIFF(WEEK, '2014-01-01 00:00:00', '2014-03-15 10:10:10') FROM Oro\\Entities\\Foo f WHERE f.id = 1"
-  sql: SELECT CAST(ROUND(EXTRACT(DAY FROM "timestamp"('2014-03-15 10:10:10') - "timestamp"('2014-01-01 00:00:00')) / 7) AS int) AS sclr0 FROM test_foo t0_ WHERE t0_.id = 1
+  sql: SELECT FLOOR(EXTRACT(DAY FROM "timestamp"('2014-03-15 10:10:10') - "timestamp"('2014-01-01 00:00:00')) / 7) AS sclr0 FROM test_foo t0_ WHERE t0_.id = 1
   expectedResult:
       - 10
 
@@ -78,14 +92,14 @@
 - functions:
     - { name: "timestampdiff", className: "Oro\\ORM\\Query\\AST\\Functions\\Numeric\\TimestampDiff", type: "numeric" }
   dql: "SELECT TIMESTAMPDIFF(QUARTER, '2014-01-01 00:00:00', '2015-04-15 10:10:10') FROM Oro\\Entities\\Foo f WHERE f.id = 1"
-  sql: SELECT CAST(ROUND((EXTRACT(YEAR from age("timestamp"('2015-04-15 10:10:10'), "timestamp"('2014-01-01 00:00:00'))) * 12 + EXTRACT(MONTH from age("timestamp"('2015-04-15 10:10:10'), "timestamp"('2014-01-01 00:00:00')))) / 3) AS int) AS sclr0 FROM test_foo t0_ WHERE t0_.id = 1
+  sql: SELECT FLOOR((EXTRACT(YEAR from age("timestamp"('2015-04-15 10:10:10'), "timestamp"('2014-01-01 00:00:00'))) * 12 + EXTRACT(MONTH from age("timestamp"('2015-04-15 10:10:10'), "timestamp"('2014-01-01 00:00:00')))) / 3) AS sclr0 FROM test_foo t0_ WHERE t0_.id = 1
   expectedResult:
       - 5
 
 - functions:
     - { name: "timestampdiff", className: "Oro\\ORM\\Query\\AST\\Functions\\Numeric\\TimestampDiff", type: "numeric" }
   dql: "SELECT TIMESTAMPDIFF(QUARTER, '2016-01-01 00:00:01', '2016-06-01 00:00:00') FROM Oro\\Entities\\Foo f WHERE f.id = 1"
-  sql: SELECT CAST(ROUND((EXTRACT(YEAR from age("timestamp"('2016-06-01 00:00:00'), "timestamp"('2016-01-01 00:00:01'))) * 12 + EXTRACT(MONTH from age("timestamp"('2016-06-01 00:00:00'), "timestamp"('2016-01-01 00:00:01')))) / 3) AS int) AS sclr0 FROM test_foo t0_ WHERE t0_.id = 1
+  sql: SELECT FLOOR((EXTRACT(YEAR from age("timestamp"('2016-06-01 00:00:00'), "timestamp"('2016-01-01 00:00:01'))) * 12 + EXTRACT(MONTH from age("timestamp"('2016-06-01 00:00:00'), "timestamp"('2016-01-01 00:00:01')))) / 3) AS sclr0 FROM test_foo t0_ WHERE t0_.id = 1
   expectedResult:
       - 1
 

--- a/tests/Oro/Tests/ORM/AST/Query/Functions/fixtures/postgresql/timestampdiff.yml
+++ b/tests/Oro/Tests/ORM/AST/Query/Functions/fixtures/postgresql/timestampdiff.yml
@@ -8,7 +8,7 @@
 - functions:
     - { name: "timestampdiff", className: "Oro\\ORM\\Query\\AST\\Functions\\Numeric\\TimestampDiff", type: "numeric" }
   dql: "SELECT TIMESTAMPDIFF(SECOND, '2014-01-01 00:00:00', '2014-01-01 00:00:10') FROM Oro\\Entities\\Foo f WHERE f.id = 1"
-  sql: SELECT CAST(ROUND((EXTRACT(EPOCH FROM "timestamp"('2014-01-01 00:00:10')) - EXTRACT(EPOCH FROM "timestamp"('2014-01-01 00:00:00')))) AS int) AS sclr0 FROM test_foo t0_ WHERE t0_.id = 1
+  sql: SELECT (EXTRACT(EPOCH FROM "timestamp"('2014-01-01 00:00:10')) - EXTRACT(EPOCH FROM "timestamp"('2014-01-01 00:00:00'))) AS sclr0 FROM test_foo t0_ WHERE t0_.id = 1
   expectedResult:
       - 10
 
@@ -29,9 +29,23 @@
 - functions:
     - { name: "timestampdiff", className: "Oro\\ORM\\Query\\AST\\Functions\\Numeric\\TimestampDiff", type: "numeric" }
   dql: "SELECT TIMESTAMPDIFF(DAY, '2014-01-01 00:00:00', '2014-01-11 10:10:10') FROM Oro\\Entities\\Foo f WHERE f.id = 1"
-  sql: SELECT CAST(ROUND(EXTRACT(DAY FROM "timestamp"('2014-01-11 10:10:10') - "timestamp"('2014-01-01 00:00:00'))) AS int) AS sclr0 FROM test_foo t0_ WHERE t0_.id = 1
+  sql: SELECT EXTRACT(DAY FROM "timestamp"('2014-01-11 10:10:10') - "timestamp"('2014-01-01 00:00:00')) AS sclr0 FROM test_foo t0_ WHERE t0_.id = 1
   expectedResult:
       - 10
+
+- functions:
+    - { name: "timestampdiff", className: "Oro\\ORM\\Query\\AST\\Functions\\Numeric\\TimestampDiff", type: "numeric" }
+  dql: "SELECT TIMESTAMPDIFF(DAY, '2016-01-01 00:00:00', '2017-01-01 00:00:00') FROM Oro\\Entities\\Foo f WHERE f.id = 1"
+  sql: SELECT EXTRACT(DAY FROM "timestamp"('2017-01-01 00:00:00') - "timestamp"('2016-01-01 00:00:00')) AS sclr0 FROM test_foo t0_ WHERE t0_.id = 1
+  expectedResult:
+      - 366
+
+- functions:
+    - { name: "timestampdiff", className: "Oro\\ORM\\Query\\AST\\Functions\\Numeric\\TimestampDiff", type: "numeric" }
+  dql: "SELECT TIMESTAMPDIFF(DAY, '2016-01-01 00:00:00', '2017-01-02 00:10:00') FROM Oro\\Entities\\Foo f WHERE f.id = 1"
+  sql: SELECT EXTRACT(DAY FROM "timestamp"('2017-01-02 00:10:00') - "timestamp"('2016-01-01 00:00:00')) AS sclr0 FROM test_foo t0_ WHERE t0_.id = 1
+  expectedResult:
+      - 367
 
 - functions:
     - { name: "timestampdiff", className: "Oro\\ORM\\Query\\AST\\Functions\\Numeric\\TimestampDiff", type: "numeric" }
@@ -42,21 +56,49 @@
 
 - functions:
     - { name: "timestampdiff", className: "Oro\\ORM\\Query\\AST\\Functions\\Numeric\\TimestampDiff", type: "numeric" }
-  dql: "SELECT TIMESTAMPDIFF(MONTH, '2014-01-01 00:00:00', '2014-03-15 10:10:10') FROM Oro\\Entities\\Foo f WHERE f.id = 1"
-  sql: SELECT CAST(ROUND((EXTRACT(YEAR FROM "timestamp"('2014-03-15 10:10:10')) - EXTRACT(YEAR FROM "timestamp"('2014-01-01 00:00:00'))) * 12 + (EXTRACT(MONTH FROM "timestamp"('2014-03-15 10:10:10')) - EXTRACT(MONTH FROM "timestamp"('2014-01-01 00:00:00')))) AS int) AS sclr0 FROM test_foo t0_ WHERE t0_.id = 1
+  dql: "SELECT TIMESTAMPDIFF(MONTH, '2016-01-01 00:00:00', '2017-01-01 00:00:00') FROM Oro\\Entities\\Foo f WHERE f.id = 1"
+  sql: SELECT (EXTRACT(YEAR from age("timestamp"('2017-01-01 00:00:00'), "timestamp"('2016-01-01 00:00:00'))) * 12 + EXTRACT(MONTH from age("timestamp"('2017-01-01 00:00:00'), "timestamp"('2016-01-01 00:00:00')))) AS sclr0 FROM test_foo t0_ WHERE t0_.id = 1
   expectedResult:
-      - 2
+      - 12
+
+- functions:
+    - { name: "timestampdiff", className: "Oro\\ORM\\Query\\AST\\Functions\\Numeric\\TimestampDiff", type: "numeric" }
+  dql: "SELECT TIMESTAMPDIFF(MONTH, '2016-01-01 00:00:01', '2017-01-01 00:00:00') FROM Oro\\Entities\\Foo f WHERE f.id = 1"
+  sql: SELECT (EXTRACT(YEAR from age("timestamp"('2017-01-01 00:00:00'), "timestamp"('2016-01-01 00:00:01'))) * 12 + EXTRACT(MONTH from age("timestamp"('2017-01-01 00:00:00'), "timestamp"('2016-01-01 00:00:01')))) AS sclr0 FROM test_foo t0_ WHERE t0_.id = 1
+  expectedResult:
+      - 11
+
+- functions:
+    - { name: "timestampdiff", className: "Oro\\ORM\\Query\\AST\\Functions\\Numeric\\TimestampDiff", type: "numeric" }
+  dql: "SELECT TIMESTAMPDIFF(MONTH, '2016-01-01 00:00:01', '2017-02-01 00:00:02') FROM Oro\\Entities\\Foo f WHERE f.id = 1"
+  sql: SELECT (EXTRACT(YEAR from age("timestamp"('2017-02-01 00:00:02'), "timestamp"('2016-01-01 00:00:01'))) * 12 + EXTRACT(MONTH from age("timestamp"('2017-02-01 00:00:02'), "timestamp"('2016-01-01 00:00:01')))) AS sclr0 FROM test_foo t0_ WHERE t0_.id = 1
+  expectedResult:
+      - 13
 
 - functions:
     - { name: "timestampdiff", className: "Oro\\ORM\\Query\\AST\\Functions\\Numeric\\TimestampDiff", type: "numeric" }
   dql: "SELECT TIMESTAMPDIFF(QUARTER, '2014-01-01 00:00:00', '2015-04-15 10:10:10') FROM Oro\\Entities\\Foo f WHERE f.id = 1"
-  sql: SELECT CAST(ROUND((EXTRACT(YEAR FROM "timestamp"('2015-04-15 10:10:10')) - EXTRACT(YEAR FROM "timestamp"('2014-01-01 00:00:00'))) * 4 + (EXTRACT(QUARTER FROM "timestamp"('2015-04-15 10:10:10')) - EXTRACT(QUARTER FROM "timestamp"('2014-01-01 00:00:00')))) AS int) AS sclr0 FROM test_foo t0_ WHERE t0_.id = 1
+  sql: SELECT CAST(ROUND((EXTRACT(YEAR from age("timestamp"('2015-04-15 10:10:10'), "timestamp"('2014-01-01 00:00:00'))) * 12 + EXTRACT(MONTH from age("timestamp"('2015-04-15 10:10:10'), "timestamp"('2014-01-01 00:00:00')))) / 3) AS int) AS sclr0 FROM test_foo t0_ WHERE t0_.id = 1
   expectedResult:
       - 5
 
 - functions:
     - { name: "timestampdiff", className: "Oro\\ORM\\Query\\AST\\Functions\\Numeric\\TimestampDiff", type: "numeric" }
-  dql: "SELECT TIMESTAMPDIFF(YEAR, '2014-01-01 00:00:00', '2015-04-15 10:10:10') FROM Oro\\Entities\\Foo f WHERE f.id = 1"
-  sql: SELECT CAST(ROUND((EXTRACT(YEAR FROM "timestamp"('2015-04-15 10:10:10')) - EXTRACT(YEAR FROM "timestamp"('2014-01-01 00:00:00')))) AS int) AS sclr0 FROM test_foo t0_ WHERE t0_.id = 1
+  dql: "SELECT TIMESTAMPDIFF(QUARTER, '2016-01-01 00:00:01', '2016-06-01 00:00:00') FROM Oro\\Entities\\Foo f WHERE f.id = 1"
+  sql: SELECT CAST(ROUND((EXTRACT(YEAR from age("timestamp"('2016-06-01 00:00:00'), "timestamp"('2016-01-01 00:00:01'))) * 12 + EXTRACT(MONTH from age("timestamp"('2016-06-01 00:00:00'), "timestamp"('2016-01-01 00:00:01')))) / 3) AS int) AS sclr0 FROM test_foo t0_ WHERE t0_.id = 1
   expectedResult:
       - 1
+
+- functions:
+    - { name: "timestampdiff", className: "Oro\\ORM\\Query\\AST\\Functions\\Numeric\\TimestampDiff", type: "numeric" }
+  dql: "SELECT TIMESTAMPDIFF(YEAR, '2016-01-01 00:00:00', '2017-01-01 00:00:00') FROM Oro\\Entities\\Foo f WHERE f.id = 1"
+  sql: SELECT EXTRACT(YEAR from age("timestamp"('2017-01-01 00:00:00'), "timestamp"('2016-01-01 00:00:00'))) AS sclr0 FROM test_foo t0_ WHERE t0_.id = 1
+  expectedResult:
+      - 1
+
+- functions:
+    - { name: "timestampdiff", className: "Oro\\ORM\\Query\\AST\\Functions\\Numeric\\TimestampDiff", type: "numeric" }
+  dql: "SELECT TIMESTAMPDIFF(YEAR, '2016-01-01 00:00:01', '2017-01-01 00:00:00') FROM Oro\\Entities\\Foo f WHERE f.id = 1"
+  sql: SELECT EXTRACT(YEAR from age("timestamp"('2017-01-01 00:00:00'), "timestamp"('2016-01-01 00:00:01'))) AS sclr0 FROM test_foo t0_ WHERE t0_.id = 1
+  expectedResult:
+      - 0


### PR DESCRIPTION
 - fixed incorrectly working TIMESTAMPDIFF for year, month and quarter 
 - fixed issue #34 