### PR TITLE
BAP-9655: Doctrine extensions: TIMESTAMPDIFF function does not work properly in PostgeSQL

### DIFF
--- a/src/Oro/ORM/Query/AST/Platform/Functions/Postgresql/Timestampdiff.php
+++ b/src/Oro/ORM/Query/AST/Platform/Functions/Postgresql/Timestampdiff.php
@@ -4,13 +4,9 @@ namespace Oro\ORM\Query\AST\Platform\Functions\Postgresql;
 
 use Doctrine\ORM\Query\AST\Node;
 use Doctrine\ORM\Query\SqlWalker;
-
-use Oro\ORM\Query\AST\Functions\Cast as CastDQL;
 use Oro\ORM\Query\AST\Functions\Numeric\TimestampDiff as BaseFunction;
-use Oro\ORM\Query\AST\Functions\SimpleFunction;
-use Oro\ORM\Query\AST\Platform\Functions\PlatformFunctionNode;
 
-class Timestampdiff extends PlatformFunctionNode
+class Timestampdiff extends AbstractTimestampAwarePlatformFunctionNode
 {
     /**
      * {@inheritdoc}
@@ -24,17 +20,7 @@ class Timestampdiff extends PlatformFunctionNode
         /** @var Node $secondDateNode */
         $secondDateNode = $this->parameters[BaseFunction::VAL2_KEY];
 
-        $castFunction = new Cast(
-            array(
-                CastDQL::PARAMETER_KEY => sprintf(
-                    'ROUND(%s)',
-                    $this->getSqlByUnit($unit, $firstDateNode, $secondDateNode, $sqlWalker)
-                ),
-                CastDQL::TYPE_KEY => 'INT'
-            )
-        );
-
-        return $castFunction->getSql($sqlWalker);
+        return $this->getSqlByUnit($unit, $firstDateNode, $secondDateNode, $sqlWalker);
     }
 
     /**
@@ -50,25 +36,8 @@ class Timestampdiff extends PlatformFunctionNode
     protected function getSqlByUnit($unit, Node $firstDateNode, Node $secondDateNode, SqlWalker $sqlWalker)
     {
         $method = 'getDiffFor' . ucfirst(strtolower($unit));
+
         return call_user_func(array($this, $method), $firstDateNode, $secondDateNode, $sqlWalker);
-    }
-
-    /**
-     * @param Node $firstDateNode
-     * @param Node $secondDateNode
-     * @param SqlWalker $sqlWalker
-     * @return string
-     */
-    protected function getDiffForSecond(Node $firstDateNode, Node $secondDateNode, SqlWalker $sqlWalker)
-    {
-        $firstDateTimestampFunction = new Timestamp(array(SimpleFunction::PARAMETER_KEY => $firstDateNode));
-        $secondDateTimestampFunction = new Timestamp(array(SimpleFunction::PARAMETER_KEY => $secondDateNode));
-
-        return sprintf(
-            '(EXTRACT(EPOCH FROM %s) - EXTRACT(EPOCH FROM %s))',
-            $secondDateTimestampFunction->getSql($sqlWalker),
-            $firstDateTimestampFunction->getSql($sqlWalker)
-        );
     }
 
     /**
@@ -79,7 +48,24 @@ class Timestampdiff extends PlatformFunctionNode
      */
     protected function getDiffForMicrosecond(Node $firstDateNode, Node $secondDateNode, SqlWalker $sqlWalker)
     {
-        return $this->getDiffForSecond($firstDateNode, $secondDateNode, $sqlWalker) . ' * 1000000';
+        return sprintf(
+            'EXTRACT(MICROSECOND FROM %s - %s)',
+            $this->getTimestampValue($secondDateNode, $sqlWalker),
+            $this->getTimestampValue($firstDateNode, $sqlWalker)
+        );
+    }
+
+    /**
+     * @param Node $firstDateNode
+     * @param Node $secondDateNode
+     * @param SqlWalker $sqlWalker
+     * @return string
+     */
+    protected function getDiffForSecond(Node $firstDateNode, Node $secondDateNode, SqlWalker $sqlWalker)
+    {
+        return $this->getFloorValue(
+            $this->getRawDiffForSecond($firstDateNode, $secondDateNode, $sqlWalker)
+        );
     }
 
     /**
@@ -90,7 +76,9 @@ class Timestampdiff extends PlatformFunctionNode
      */
     protected function getDiffForMinute(Node $firstDateNode, Node $secondDateNode, SqlWalker $sqlWalker)
     {
-        return $this->getDiffForSecond($firstDateNode, $secondDateNode, $sqlWalker) . ' / 60';
+        return $this->getFloorValue(
+            $this->getRawDiffForSecond($firstDateNode, $secondDateNode, $sqlWalker) . ' / 60'
+        );
     }
 
     /**
@@ -101,7 +89,9 @@ class Timestampdiff extends PlatformFunctionNode
      */
     protected function getDiffForHour(Node $firstDateNode, Node $secondDateNode, SqlWalker $sqlWalker)
     {
-        return $this->getDiffForSecond($firstDateNode, $secondDateNode, $sqlWalker) . ' / 3600';
+        return $this->getFloorValue(
+            $this->getRawDiffForSecond($firstDateNode, $secondDateNode, $sqlWalker) . ' / 3600'
+        );
     }
 
     /**
@@ -112,13 +102,10 @@ class Timestampdiff extends PlatformFunctionNode
      */
     protected function getDiffForDay(Node $firstDateNode, Node $secondDateNode, SqlWalker $sqlWalker)
     {
-        $firstDateTimestampFunction = new Timestamp(array(SimpleFunction::PARAMETER_KEY => $firstDateNode));
-        $secondDateTimestampFunction = new Timestamp(array(SimpleFunction::PARAMETER_KEY => $secondDateNode));
-
         return sprintf(
             'EXTRACT(DAY FROM %s - %s)',
-            $secondDateTimestampFunction->getSql($sqlWalker),
-            $firstDateTimestampFunction->getSql($sqlWalker)
+            $this->getTimestampValue($secondDateNode, $sqlWalker),
+            $this->getTimestampValue($firstDateNode, $sqlWalker)
         );
     }
 
@@ -130,24 +117,8 @@ class Timestampdiff extends PlatformFunctionNode
      */
     protected function getDiffForWeek(Node $firstDateNode, Node $secondDateNode, SqlWalker $sqlWalker)
     {
-        return $this->getDiffForDay($firstDateNode, $secondDateNode, $sqlWalker) . ' / 7';
-    }
-
-    /**
-     * @param Node $firstDateNode
-     * @param Node $secondDateNode
-     * @param SqlWalker $sqlWalker
-     * @return string
-     */
-    protected function getDiffForYear(Node $firstDateNode, Node $secondDateNode, SqlWalker $sqlWalker)
-    {
-        $firstDateYearFunction = new Year(array(SimpleFunction::PARAMETER_KEY => $firstDateNode));
-        $secondDateYearFunction = new Year(array(SimpleFunction::PARAMETER_KEY => $secondDateNode));
-
-        return sprintf(
-            '(%s - %s)',
-            $secondDateYearFunction->getSql($sqlWalker),
-            $firstDateYearFunction->getSql($sqlWalker)
+        return $this->getFloorValue(
+            $this->getDiffForDay($firstDateNode, $secondDateNode, $sqlWalker) . ' / 7'
         );
     }
 
@@ -159,14 +130,18 @@ class Timestampdiff extends PlatformFunctionNode
      */
     protected function getDiffForMonth(Node $firstDateNode, Node $secondDateNode, SqlWalker $sqlWalker)
     {
-        $firstDateMonthFunction = new Month(array(SimpleFunction::PARAMETER_KEY => $firstDateNode));
-        $secondDateMonthFunction = new Month(array(SimpleFunction::PARAMETER_KEY => $secondDateNode));
+        $firstDateTimestamp = $this->getTimestampValue($firstDateNode, $sqlWalker);
+        $secondDateTimestamp = $this->getTimestampValue($secondDateNode, $sqlWalker);
+
+        $months = sprintf(
+            'EXTRACT(MONTH from %s)',
+            $this->getAge($firstDateTimestamp, $secondDateTimestamp)
+        );
 
         return sprintf(
-            '%s * 12 + (%s - %s)',
+            '(%s * 12 + %s)',
             $this->getDiffForYear($firstDateNode, $secondDateNode, $sqlWalker),
-            $secondDateMonthFunction->getSql($sqlWalker),
-            $firstDateMonthFunction->getSql($sqlWalker)
+            $months
         );
     }
 
@@ -178,14 +153,56 @@ class Timestampdiff extends PlatformFunctionNode
      */
     protected function getDiffForQuarter(Node $firstDateNode, Node $secondDateNode, SqlWalker $sqlWalker)
     {
-        $firstDateQuarterFunction = new Quarter(array(SimpleFunction::PARAMETER_KEY => $firstDateNode));
-        $secondDateQuarterFunction = new Quarter(array(SimpleFunction::PARAMETER_KEY => $secondDateNode));
+        return $this->getFloorValue(
+            $this->getDiffForMonth($firstDateNode, $secondDateNode, $sqlWalker) . ' / 3'
+        );
+    }
 
+    /**
+     * @param Node $firstDateNode
+     * @param Node $secondDateNode
+     * @param SqlWalker $sqlWalker
+     * @return string
+     */
+    protected function getDiffForYear(Node $firstDateNode, Node $secondDateNode, SqlWalker $sqlWalker)
+    {
+        $firstDateTimestamp = $this->getTimestampValue($firstDateNode, $sqlWalker);
+        $secondDateTimestamp = $this->getTimestampValue($secondDateNode, $sqlWalker);
+
+        return sprintf('EXTRACT(YEAR from %s)', $this->getAge($firstDateTimestamp, $secondDateTimestamp));
+    }
+
+    /**
+     * @param string $firstDateTimestamp
+     * @param string $secondDateTimestamp
+     * @return string
+     */
+    protected function getAge($firstDateTimestamp, $secondDateTimestamp)
+    {
+        return sprintf('age(%s, %s)', $secondDateTimestamp, $firstDateTimestamp);
+    }
+
+    /**
+     * @param string $value
+     * @return string
+     */
+    protected function getFloorValue($value)
+    {
+        return sprintf('FLOOR(%s)', $value);
+    }
+
+    /**
+     * @param Node $firstDateNode
+     * @param Node $secondDateNode
+     * @param SqlWalker $sqlWalker
+     * @return string
+     */
+    protected function getRawDiffForSecond(Node $firstDateNode, Node $secondDateNode, SqlWalker $sqlWalker)
+    {
         return sprintf(
-            '%s * 4 + (%s - %s)',
-            $this->getDiffForYear($firstDateNode, $secondDateNode, $sqlWalker),
-            $secondDateQuarterFunction->getSql($sqlWalker),
-            $firstDateQuarterFunction->getSql($sqlWalker)
+            'EXTRACT(EPOCH FROM %s - %s)',
+            $this->getTimestampValue($secondDateNode, $sqlWalker),
+            $this->getTimestampValue($firstDateNode, $sqlWalker)
         );
     }
 }

--- a/tests/Oro/Tests/ORM/AST/Query/Functions/fixtures/mysql/cast.yml
+++ b/tests/Oro/Tests/ORM/AST/Query/Functions/fixtures/mysql/cast.yml
@@ -1,10 +1,17 @@
 #INT
 - functions:
     - { name: "cast", className: "Oro\\ORM\\Query\\AST\\Functions\\Cast", type: "numeric" }
-  dql: "SELECT CAST('123' as int) FROM Oro\\Entities\\Foo f WHERE f.id = 1"
-  sql: "SELECT CAST('123' AS signed) AS sclr0 FROM test_foo t0_ WHERE t0_.id = 1"
+  dql: "SELECT CAST(12 as int) FROM Oro\\Entities\\Foo f WHERE f.id = 1"
+  sql: "SELECT CAST(12 AS signed) AS sclr0 FROM test_foo t0_ WHERE t0_.id = 1"
   expectedResult:
-      - 123
+      - 12
+
+- functions:
+    - { name: "cast", className: "Oro\\ORM\\Query\\AST\\Functions\\Cast", type: "numeric" }
+  dql: "SELECT CAST('12' as int) FROM Oro\\Entities\\Foo f WHERE f.id = 1"
+  sql: "SELECT CAST('12' AS signed) AS sclr0 FROM test_foo t0_ WHERE t0_.id = 1"
+  expectedResult:
+      - 12
 
 #INTEGER
 - functions:

--- a/tests/Oro/Tests/ORM/AST/Query/Functions/fixtures/mysql/timestampdiff.yml
+++ b/tests/Oro/Tests/ORM/AST/Query/Functions/fixtures/mysql/timestampdiff.yml
@@ -7,15 +7,29 @@
 
 - functions:
     - { name: "timestampdiff", className: "Oro\\ORM\\Query\\AST\\Functions\\Numeric\\TimestampDiff", type: "numeric" }
-  dql: "SELECT TIMESTAMPDIFF(SECOND, '2014-01-01 00:00:00', '2014-01-01 00:00:10') FROM Oro\\Entities\\Foo f WHERE f.id = 1"
-  sql: SELECT TIMESTAMPDIFF(SECOND, '2014-01-01 00:00:00', '2014-01-01 00:00:10') AS sclr0 FROM test_foo t0_ WHERE t0_.id = 1
+  dql: "SELECT TIMESTAMPDIFF(MICROSECOND, '2014-01-01 00:00:00.121212', '2014-01-01 00:00:03') FROM Oro\\Entities\\Foo f WHERE f.id = 1"
+  sql: SELECT TIMESTAMPDIFF(MICROSECOND, '2014-01-01 00:00:00.121212', '2014-01-01 00:00:03') AS sclr0 FROM test_foo t0_ WHERE t0_.id = 1
   expectedResult:
-      - 10
+      - 2878788
 
 - functions:
     - { name: "timestampdiff", className: "Oro\\ORM\\Query\\AST\\Functions\\Numeric\\TimestampDiff", type: "numeric" }
-  dql: "SELECT TIMESTAMPDIFF(MINUTE, '2014-01-01 00:00:00', '2014-01-01 00:10:10') FROM Oro\\Entities\\Foo f WHERE f.id = 1"
-  sql: SELECT TIMESTAMPDIFF(MINUTE, '2014-01-01 00:00:00', '2014-01-01 00:10:10') AS sclr0 FROM test_foo t0_ WHERE t0_.id = 1
+  dql: "SELECT TIMESTAMPDIFF(SECOND, '2014-01-01 00:00:00.123', '2014-01-01 00:00:10') FROM Oro\\Entities\\Foo f WHERE f.id = 1"
+  sql: SELECT TIMESTAMPDIFF(SECOND, '2014-01-01 00:00:00.123', '2014-01-01 00:00:10') AS sclr0 FROM test_foo t0_ WHERE t0_.id = 1
+  expectedResult:
+      - 9
+
+- functions:
+    - { name: "timestampdiff", className: "Oro\\ORM\\Query\\AST\\Functions\\Numeric\\TimestampDiff", type: "numeric" }
+  dql: "SELECT TIMESTAMPDIFF(SECOND, '2014-01-01 00:00:00.111', '2014-01-01 00:00:07.845') FROM Oro\\Entities\\Foo f WHERE f.id = 1"
+  sql: SELECT TIMESTAMPDIFF(SECOND, '2014-01-01 00:00:00.111', '2014-01-01 00:00:07.845') AS sclr0 FROM test_foo t0_ WHERE t0_.id = 1
+  expectedResult:
+      - 7
+
+- functions:
+    - { name: "timestampdiff", className: "Oro\\ORM\\Query\\AST\\Functions\\Numeric\\TimestampDiff", type: "numeric" }
+  dql: "SELECT TIMESTAMPDIFF(MINUTE, '2014-01-01 00:00:00', '2014-01-01 00:10:40') FROM Oro\\Entities\\Foo f WHERE f.id = 1"
+  sql: SELECT TIMESTAMPDIFF(MINUTE, '2014-01-01 00:00:00', '2014-01-01 00:10:40') AS sclr0 FROM test_foo t0_ WHERE t0_.id = 1
   expectedResult:
       - 10
 
@@ -35,6 +49,20 @@
 
 - functions:
     - { name: "timestampdiff", className: "Oro\\ORM\\Query\\AST\\Functions\\Numeric\\TimestampDiff", type: "numeric" }
+  dql: "SELECT TIMESTAMPDIFF(DAY, '2016-01-01 00:00:00', '2017-01-01 00:00:00') FROM Oro\\Entities\\Foo f WHERE f.id = 1"
+  sql: SELECT TIMESTAMPDIFF(DAY, '2016-01-01 00:00:00', '2017-01-01 00:00:00') AS sclr0 FROM test_foo t0_ WHERE t0_.id = 1
+  expectedResult:
+      - 366
+
+- functions:
+    - { name: "timestampdiff", className: "Oro\\ORM\\Query\\AST\\Functions\\Numeric\\TimestampDiff", type: "numeric" }
+  dql: "SELECT TIMESTAMPDIFF(DAY, '2016-01-01 00:00:00', '2017-01-02 00:10:00') FROM Oro\\Entities\\Foo f WHERE f.id = 1"
+  sql: SELECT TIMESTAMPDIFF(DAY, '2016-01-01 00:00:00', '2017-01-02 00:10:00') AS sclr0 FROM test_foo t0_ WHERE t0_.id = 1
+  expectedResult:
+      - 367
+
+- functions:
+    - { name: "timestampdiff", className: "Oro\\ORM\\Query\\AST\\Functions\\Numeric\\TimestampDiff", type: "numeric" }
   dql: "SELECT TIMESTAMPDIFF(WEEK, '2014-01-01 00:00:00', '2014-03-15 10:10:10') FROM Oro\\Entities\\Foo f WHERE f.id = 1"
   sql: SELECT TIMESTAMPDIFF(WEEK, '2014-01-01 00:00:00', '2014-03-15 10:10:10') AS sclr0 FROM test_foo t0_ WHERE t0_.id = 1
   expectedResult:
@@ -42,10 +70,24 @@
 
 - functions:
     - { name: "timestampdiff", className: "Oro\\ORM\\Query\\AST\\Functions\\Numeric\\TimestampDiff", type: "numeric" }
-  dql: "SELECT TIMESTAMPDIFF(MONTH, '2014-01-01 00:00:00', '2014-03-15 10:10:10') FROM Oro\\Entities\\Foo f WHERE f.id = 1"
-  sql: SELECT TIMESTAMPDIFF(MONTH, '2014-01-01 00:00:00', '2014-03-15 10:10:10') AS sclr0 FROM test_foo t0_ WHERE t0_.id = 1
+  dql: "SELECT TIMESTAMPDIFF(MONTH, '2016-01-01 00:00:00', '2017-01-01 00:00:00') FROM Oro\\Entities\\Foo f WHERE f.id = 1"
+  sql: SELECT TIMESTAMPDIFF(MONTH, '2016-01-01 00:00:00', '2017-01-01 00:00:00') AS sclr0 FROM test_foo t0_ WHERE t0_.id = 1
   expectedResult:
-      - 2
+      - 12
+
+- functions:
+    - { name: "timestampdiff", className: "Oro\\ORM\\Query\\AST\\Functions\\Numeric\\TimestampDiff", type: "numeric" }
+  dql: "SELECT TIMESTAMPDIFF(MONTH, '2016-01-01 00:00:01', '2017-01-01 00:00:00') FROM Oro\\Entities\\Foo f WHERE f.id = 1"
+  sql: SELECT TIMESTAMPDIFF(MONTH, '2016-01-01 00:00:01', '2017-01-01 00:00:00') AS sclr0 FROM test_foo t0_ WHERE t0_.id = 1
+  expectedResult:
+      - 11
+
+- functions:
+    - { name: "timestampdiff", className: "Oro\\ORM\\Query\\AST\\Functions\\Numeric\\TimestampDiff", type: "numeric" }
+  dql: "SELECT TIMESTAMPDIFF(MONTH, '2016-01-01 00:00:01', '2017-02-01 00:00:02') FROM Oro\\Entities\\Foo f WHERE f.id = 1"
+  sql: SELECT TIMESTAMPDIFF(MONTH, '2016-01-01 00:00:01', '2017-02-01 00:00:02') AS sclr0 FROM test_foo t0_ WHERE t0_.id = 1
+  expectedResult:
+      - 13
 
 - functions:
     - { name: "timestampdiff", className: "Oro\\ORM\\Query\\AST\\Functions\\Numeric\\TimestampDiff", type: "numeric" }
@@ -56,7 +98,22 @@
 
 - functions:
     - { name: "timestampdiff", className: "Oro\\ORM\\Query\\AST\\Functions\\Numeric\\TimestampDiff", type: "numeric" }
-  dql: "SELECT TIMESTAMPDIFF(YEAR, '2014-01-01 00:00:00', '2015-04-15 10:10:10') FROM Oro\\Entities\\Foo f WHERE f.id = 1"
-  sql: SELECT TIMESTAMPDIFF(YEAR, '2014-01-01 00:00:00', '2015-04-15 10:10:10') AS sclr0 FROM test_foo t0_ WHERE t0_.id = 1
+  dql: "SELECT TIMESTAMPDIFF(QUARTER, '2016-01-01 00:00:01', '2016-06-01 00:00:00') FROM Oro\\Entities\\Foo f WHERE f.id = 1"
+  sql: SELECT TIMESTAMPDIFF(QUARTER, '2016-01-01 00:00:01', '2016-06-01 00:00:00') AS sclr0 FROM test_foo t0_ WHERE t0_.id = 1
   expectedResult:
       - 1
+
+- functions:
+    - { name: "timestampdiff", className: "Oro\\ORM\\Query\\AST\\Functions\\Numeric\\TimestampDiff", type: "numeric" }
+  dql: "SELECT TIMESTAMPDIFF(YEAR, '2016-01-01 00:00:00', '2017-01-01 00:00:00') FROM Oro\\Entities\\Foo f WHERE f.id = 1"
+  sql: SELECT TIMESTAMPDIFF(YEAR, '2016-01-01 00:00:00', '2017-01-01 00:00:00') AS sclr0 FROM test_foo t0_ WHERE t0_.id = 1
+  expectedResult:
+      - 1
+
+- functions:
+    - { name: "timestampdiff", className: "Oro\\ORM\\Query\\AST\\Functions\\Numeric\\TimestampDiff", type: "numeric" }
+  dql: "SELECT TIMESTAMPDIFF(YEAR, '2016-01-01 00:00:01', '2017-01-01 00:00:00') FROM Oro\\Entities\\Foo f WHERE f.id = 1"
+  sql: SELECT TIMESTAMPDIFF(YEAR, '2016-01-01 00:00:01', '2017-01-01 00:00:00') AS sclr0 FROM test_foo t0_ WHERE t0_.id = 1
+  expectedResult:
+      - 0
+

--- a/tests/Oro/Tests/ORM/AST/Query/Functions/fixtures/postgresql/timestampdiff.yml
+++ b/tests/Oro/Tests/ORM/AST/Query/Functions/fixtures/postgresql/timestampdiff.yml
@@ -1,62 +1,118 @@
 - functions:
     - { name: "timestampdiff", className: "Oro\\ORM\\Query\\AST\\Functions\\Numeric\\TimestampDiff", type: "numeric" }
   dql: "SELECT TIMESTAMPDIFF(MICROSECOND, '2014-01-01 00:00:00', '2014-01-01 00:00:10.100') FROM Oro\\Entities\\Foo f WHERE f.id = 1"
-  sql: SELECT CAST(ROUND((EXTRACT(EPOCH FROM "timestamp"('2014-01-01 00:00:10.100')) - EXTRACT(EPOCH FROM "timestamp"('2014-01-01 00:00:00'))) * 1000000) AS int) AS sclr0 FROM test_foo t0_ WHERE t0_.id = 1
+  sql: SELECT EXTRACT(MICROSECOND FROM "timestamp"('2014-01-01 00:00:10.100') - "timestamp"('2014-01-01 00:00:00')) AS sclr0 FROM test_foo t0_ WHERE t0_.id = 1
   expectedResult:
       - 10100000
 
 - functions:
     - { name: "timestampdiff", className: "Oro\\ORM\\Query\\AST\\Functions\\Numeric\\TimestampDiff", type: "numeric" }
-  dql: "SELECT TIMESTAMPDIFF(SECOND, '2014-01-01 00:00:00', '2014-01-01 00:00:10') FROM Oro\\Entities\\Foo f WHERE f.id = 1"
-  sql: SELECT CAST(ROUND((EXTRACT(EPOCH FROM "timestamp"('2014-01-01 00:00:10')) - EXTRACT(EPOCH FROM "timestamp"('2014-01-01 00:00:00')))) AS int) AS sclr0 FROM test_foo t0_ WHERE t0_.id = 1
+  dql: "SELECT TIMESTAMPDIFF(MICROSECOND, '2014-01-01 00:00:00.121212', '2014-01-01 00:00:03') FROM Oro\\Entities\\Foo f WHERE f.id = 1"
+  sql: SELECT EXTRACT(MICROSECOND FROM "timestamp"('2014-01-01 00:00:03') - "timestamp"('2014-01-01 00:00:00.121212')) AS sclr0 FROM test_foo t0_ WHERE t0_.id = 1
   expectedResult:
-      - 10
+      - 2878788
 
 - functions:
     - { name: "timestampdiff", className: "Oro\\ORM\\Query\\AST\\Functions\\Numeric\\TimestampDiff", type: "numeric" }
-  dql: "SELECT TIMESTAMPDIFF(MINUTE, '2014-01-01 00:00:00', '2014-01-01 00:10:10') FROM Oro\\Entities\\Foo f WHERE f.id = 1"
-  sql: SELECT CAST(ROUND((EXTRACT(EPOCH FROM "timestamp"('2014-01-01 00:10:10')) - EXTRACT(EPOCH FROM "timestamp"('2014-01-01 00:00:00'))) / 60) AS int) AS sclr0 FROM test_foo t0_ WHERE t0_.id = 1
+  dql: "SELECT TIMESTAMPDIFF(SECOND, '2014-01-01 00:00:00.123', '2014-01-01 00:00:10') FROM Oro\\Entities\\Foo f WHERE f.id = 1"
+  sql: SELECT FLOOR(EXTRACT(EPOCH FROM "timestamp"('2014-01-01 00:00:10') - "timestamp"('2014-01-01 00:00:00.123'))) AS sclr0 FROM test_foo t0_ WHERE t0_.id = 1
+  expectedResult:
+      - 9
+
+- functions:
+    - { name: "timestampdiff", className: "Oro\\ORM\\Query\\AST\\Functions\\Numeric\\TimestampDiff", type: "numeric" }
+  dql: "SELECT TIMESTAMPDIFF(SECOND, '2014-01-01 00:00:00.111', '2014-01-01 00:00:07.845') FROM Oro\\Entities\\Foo f WHERE f.id = 1"
+  sql: SELECT FLOOR(EXTRACT(EPOCH FROM "timestamp"('2014-01-01 00:00:07.845') - "timestamp"('2014-01-01 00:00:00.111'))) AS sclr0 FROM test_foo t0_ WHERE t0_.id = 1
+  expectedResult:
+      - 7
+
+- functions:
+    - { name: "timestampdiff", className: "Oro\\ORM\\Query\\AST\\Functions\\Numeric\\TimestampDiff", type: "numeric" }
+  dql: "SELECT TIMESTAMPDIFF(MINUTE, '2014-01-01 00:00:00', '2014-01-01 00:10:40') FROM Oro\\Entities\\Foo f WHERE f.id = 1"
+  sql: SELECT FLOOR(EXTRACT(EPOCH FROM "timestamp"('2014-01-01 00:10:40') - "timestamp"('2014-01-01 00:00:00')) / 60) AS sclr0 FROM test_foo t0_ WHERE t0_.id = 1
   expectedResult:
       - 10
 
 - functions:
     - { name: "timestampdiff", className: "Oro\\ORM\\Query\\AST\\Functions\\Numeric\\TimestampDiff", type: "numeric" }
   dql: "SELECT TIMESTAMPDIFF(HOUR, '2014-01-01 00:00:00', '2014-01-01 10:10:10') FROM Oro\\Entities\\Foo f WHERE f.id = 1"
-  sql: SELECT CAST(ROUND((EXTRACT(EPOCH FROM "timestamp"('2014-01-01 10:10:10')) - EXTRACT(EPOCH FROM "timestamp"('2014-01-01 00:00:00'))) / 3600) AS int) AS sclr0 FROM test_foo t0_ WHERE t0_.id = 1
+  sql: SELECT FLOOR(EXTRACT(EPOCH FROM "timestamp"('2014-01-01 10:10:10') - "timestamp"('2014-01-01 00:00:00')) / 3600) AS sclr0 FROM test_foo t0_ WHERE t0_.id = 1
   expectedResult:
       - 10
 
 - functions:
     - { name: "timestampdiff", className: "Oro\\ORM\\Query\\AST\\Functions\\Numeric\\TimestampDiff", type: "numeric" }
   dql: "SELECT TIMESTAMPDIFF(DAY, '2014-01-01 00:00:00', '2014-01-11 10:10:10') FROM Oro\\Entities\\Foo f WHERE f.id = 1"
-  sql: SELECT CAST(ROUND(EXTRACT(DAY FROM "timestamp"('2014-01-11 10:10:10') - "timestamp"('2014-01-01 00:00:00'))) AS int) AS sclr0 FROM test_foo t0_ WHERE t0_.id = 1
+  sql: SELECT EXTRACT(DAY FROM "timestamp"('2014-01-11 10:10:10') - "timestamp"('2014-01-01 00:00:00')) AS sclr0 FROM test_foo t0_ WHERE t0_.id = 1
   expectedResult:
       - 10
+
+- functions:
+    - { name: "timestampdiff", className: "Oro\\ORM\\Query\\AST\\Functions\\Numeric\\TimestampDiff", type: "numeric" }
+  dql: "SELECT TIMESTAMPDIFF(DAY, '2016-01-01 00:00:00', '2017-01-01 00:00:00') FROM Oro\\Entities\\Foo f WHERE f.id = 1"
+  sql: SELECT EXTRACT(DAY FROM "timestamp"('2017-01-01 00:00:00') - "timestamp"('2016-01-01 00:00:00')) AS sclr0 FROM test_foo t0_ WHERE t0_.id = 1
+  expectedResult:
+      - 366
+
+- functions:
+    - { name: "timestampdiff", className: "Oro\\ORM\\Query\\AST\\Functions\\Numeric\\TimestampDiff", type: "numeric" }
+  dql: "SELECT TIMESTAMPDIFF(DAY, '2016-01-01 00:00:00', '2017-01-02 00:10:00') FROM Oro\\Entities\\Foo f WHERE f.id = 1"
+  sql: SELECT EXTRACT(DAY FROM "timestamp"('2017-01-02 00:10:00') - "timestamp"('2016-01-01 00:00:00')) AS sclr0 FROM test_foo t0_ WHERE t0_.id = 1
+  expectedResult:
+      - 367
 
 - functions:
     - { name: "timestampdiff", className: "Oro\\ORM\\Query\\AST\\Functions\\Numeric\\TimestampDiff", type: "numeric" }
   dql: "SELECT TIMESTAMPDIFF(WEEK, '2014-01-01 00:00:00', '2014-03-15 10:10:10') FROM Oro\\Entities\\Foo f WHERE f.id = 1"
-  sql: SELECT CAST(ROUND(EXTRACT(DAY FROM "timestamp"('2014-03-15 10:10:10') - "timestamp"('2014-01-01 00:00:00')) / 7) AS int) AS sclr0 FROM test_foo t0_ WHERE t0_.id = 1
+  sql: SELECT FLOOR(EXTRACT(DAY FROM "timestamp"('2014-03-15 10:10:10') - "timestamp"('2014-01-01 00:00:00')) / 7) AS sclr0 FROM test_foo t0_ WHERE t0_.id = 1
   expectedResult:
       - 10
 
 - functions:
     - { name: "timestampdiff", className: "Oro\\ORM\\Query\\AST\\Functions\\Numeric\\TimestampDiff", type: "numeric" }
-  dql: "SELECT TIMESTAMPDIFF(MONTH, '2014-01-01 00:00:00', '2014-03-15 10:10:10') FROM Oro\\Entities\\Foo f WHERE f.id = 1"
-  sql: SELECT CAST(ROUND((EXTRACT(YEAR FROM "timestamp"('2014-03-15 10:10:10')) - EXTRACT(YEAR FROM "timestamp"('2014-01-01 00:00:00'))) * 12 + (EXTRACT(MONTH FROM "timestamp"('2014-03-15 10:10:10')) - EXTRACT(MONTH FROM "timestamp"('2014-01-01 00:00:00')))) AS int) AS sclr0 FROM test_foo t0_ WHERE t0_.id = 1
+  dql: "SELECT TIMESTAMPDIFF(MONTH, '2016-01-01 00:00:00', '2017-01-01 00:00:00') FROM Oro\\Entities\\Foo f WHERE f.id = 1"
+  sql: SELECT (EXTRACT(YEAR from age("timestamp"('2017-01-01 00:00:00'), "timestamp"('2016-01-01 00:00:00'))) * 12 + EXTRACT(MONTH from age("timestamp"('2017-01-01 00:00:00'), "timestamp"('2016-01-01 00:00:00')))) AS sclr0 FROM test_foo t0_ WHERE t0_.id = 1
   expectedResult:
-      - 2
+      - 12
+
+- functions:
+    - { name: "timestampdiff", className: "Oro\\ORM\\Query\\AST\\Functions\\Numeric\\TimestampDiff", type: "numeric" }
+  dql: "SELECT TIMESTAMPDIFF(MONTH, '2016-01-01 00:00:01', '2017-01-01 00:00:00') FROM Oro\\Entities\\Foo f WHERE f.id = 1"
+  sql: SELECT (EXTRACT(YEAR from age("timestamp"('2017-01-01 00:00:00'), "timestamp"('2016-01-01 00:00:01'))) * 12 + EXTRACT(MONTH from age("timestamp"('2017-01-01 00:00:00'), "timestamp"('2016-01-01 00:00:01')))) AS sclr0 FROM test_foo t0_ WHERE t0_.id = 1
+  expectedResult:
+      - 11
+
+- functions:
+    - { name: "timestampdiff", className: "Oro\\ORM\\Query\\AST\\Functions\\Numeric\\TimestampDiff", type: "numeric" }
+  dql: "SELECT TIMESTAMPDIFF(MONTH, '2016-01-01 00:00:01', '2017-02-01 00:00:02') FROM Oro\\Entities\\Foo f WHERE f.id = 1"
+  sql: SELECT (EXTRACT(YEAR from age("timestamp"('2017-02-01 00:00:02'), "timestamp"('2016-01-01 00:00:01'))) * 12 + EXTRACT(MONTH from age("timestamp"('2017-02-01 00:00:02'), "timestamp"('2016-01-01 00:00:01')))) AS sclr0 FROM test_foo t0_ WHERE t0_.id = 1
+  expectedResult:
+      - 13
 
 - functions:
     - { name: "timestampdiff", className: "Oro\\ORM\\Query\\AST\\Functions\\Numeric\\TimestampDiff", type: "numeric" }
   dql: "SELECT TIMESTAMPDIFF(QUARTER, '2014-01-01 00:00:00', '2015-04-15 10:10:10') FROM Oro\\Entities\\Foo f WHERE f.id = 1"
-  sql: SELECT CAST(ROUND((EXTRACT(YEAR FROM "timestamp"('2015-04-15 10:10:10')) - EXTRACT(YEAR FROM "timestamp"('2014-01-01 00:00:00'))) * 4 + (EXTRACT(QUARTER FROM "timestamp"('2015-04-15 10:10:10')) - EXTRACT(QUARTER FROM "timestamp"('2014-01-01 00:00:00')))) AS int) AS sclr0 FROM test_foo t0_ WHERE t0_.id = 1
+  sql: SELECT FLOOR((EXTRACT(YEAR from age("timestamp"('2015-04-15 10:10:10'), "timestamp"('2014-01-01 00:00:00'))) * 12 + EXTRACT(MONTH from age("timestamp"('2015-04-15 10:10:10'), "timestamp"('2014-01-01 00:00:00')))) / 3) AS sclr0 FROM test_foo t0_ WHERE t0_.id = 1
   expectedResult:
       - 5
 
 - functions:
     - { name: "timestampdiff", className: "Oro\\ORM\\Query\\AST\\Functions\\Numeric\\TimestampDiff", type: "numeric" }
-  dql: "SELECT TIMESTAMPDIFF(YEAR, '2014-01-01 00:00:00', '2015-04-15 10:10:10') FROM Oro\\Entities\\Foo f WHERE f.id = 1"
-  sql: SELECT CAST(ROUND((EXTRACT(YEAR FROM "timestamp"('2015-04-15 10:10:10')) - EXTRACT(YEAR FROM "timestamp"('2014-01-01 00:00:00')))) AS int) AS sclr0 FROM test_foo t0_ WHERE t0_.id = 1
+  dql: "SELECT TIMESTAMPDIFF(QUARTER, '2016-01-01 00:00:01', '2016-06-01 00:00:00') FROM Oro\\Entities\\Foo f WHERE f.id = 1"
+  sql: SELECT FLOOR((EXTRACT(YEAR from age("timestamp"('2016-06-01 00:00:00'), "timestamp"('2016-01-01 00:00:01'))) * 12 + EXTRACT(MONTH from age("timestamp"('2016-06-01 00:00:00'), "timestamp"('2016-01-01 00:00:01')))) / 3) AS sclr0 FROM test_foo t0_ WHERE t0_.id = 1
   expectedResult:
       - 1
+
+- functions:
+    - { name: "timestampdiff", className: "Oro\\ORM\\Query\\AST\\Functions\\Numeric\\TimestampDiff", type: "numeric" }
+  dql: "SELECT TIMESTAMPDIFF(YEAR, '2016-01-01 00:00:00', '2017-01-01 00:00:00') FROM Oro\\Entities\\Foo f WHERE f.id = 1"
+  sql: SELECT EXTRACT(YEAR from age("timestamp"('2017-01-01 00:00:00'), "timestamp"('2016-01-01 00:00:00'))) AS sclr0 FROM test_foo t0_ WHERE t0_.id = 1
+  expectedResult:
+      - 1
+
+- functions:
+    - { name: "timestampdiff", className: "Oro\\ORM\\Query\\AST\\Functions\\Numeric\\TimestampDiff", type: "numeric" }
+  dql: "SELECT TIMESTAMPDIFF(YEAR, '2016-01-01 00:00:01', '2017-01-01 00:00:00') FROM Oro\\Entities\\Foo f WHERE f.id = 1"
+  sql: SELECT EXTRACT(YEAR from age("timestamp"('2017-01-01 00:00:00'), "timestamp"('2016-01-01 00:00:01'))) AS sclr0 FROM test_foo t0_ WHERE t0_.id = 1
+  expectedResult:
+      - 0


### PR DESCRIPTION

 - fixed years, months, quarters
 - fixed minutes, seconds and hours diff for timestamps with microseconds